### PR TITLE
chore: polish release docs and smoke checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@
 
 ## Overview
 
-UFO is an open-source unsupervised reinforcement learning framework for humanoid control. The `main` branch focuses on MJLab training, robot-aware motion-data import, tracking/goal/reward inference, and ONNX export. The most complete and best-tested path is currently Unitree G1.
+UFO is a source-available research framework for humanoid control. The `main` branch focuses on MJLab training, robot-aware motion-data import, tracking/goal/reward inference, and ONNX export. The most complete and best-tested path is currently Unitree G1.
 
 UFO is designed to separate the learning pipeline from robot-specific configuration where practical, but new robot bring-up is still experimental. A new robot requires a MuJoCo XML, optionally a matching URDF, and motion data that has already been adapted or retargeted to that robot in RobotState format. UFO does not automatically retarget human motion or another robot's motion to a new robot, and one checkpoint cannot be directly reused across robots with different bodies, actions, or observation dimensions.
 
@@ -75,11 +75,14 @@ Install the environment:
 uv sync
 ```
 
-For W&B logging, authenticate before starting a multi-process run:
+### Optional: W&B logging
+
+W&B logging is optional. To enable it, authenticate first, optionally set your own entity, then add `--use-wandb --wandb-run-name ...` to a training command:
 
 ```bash
 uv run wandb login
-# Or: export WANDB_API_KEY=your_wandb_api_key
+export WANDB_ENTITY=your_entity   # optional
+# then add --use-wandb --wandb-run-name ufo_fb_g1
 ```
 
 ## Path A: Unitree G1 Quick Start
@@ -122,9 +125,7 @@ CUDA_VISIBLE_DEVICES=0,1,2,3,4,5,6,7 \
   --work-dir runs/ufo_fb_g1 \
   --data-path humanoidverse/data/lafan_29dof_10s-clipped.pkl \
   --update-z-every-step 100 \
-  --buffer-size 5120000 \
-  --use-wandb \
-  --wandb-run-name ufo_fb_g1
+  --buffer-size 5120000
 ```
 
 ### 4. TeCH training on G1
@@ -139,9 +140,7 @@ CUDA_VISIBLE_DEVICES=0,1,2,3,4,5,6,7 \
   --work-dir runs/ufo_tech_g1 \
   --data-path humanoidverse/data/lafan_29dof_10s-clipped.pkl \
   --update-z-every-step 10 \
-  --buffer-size 5120000 \
-  --use-wandb \
-  --wandb-run-name ufo_tech_g1
+  --buffer-size 5120000
 ```
 
 TeCH was previously exposed as TLDR in early UFO versions. `--agent tldr` is kept as a deprecated compatibility alias for `--agent tech`.
@@ -261,4 +260,4 @@ If you find UFO useful in your research, please cite:
 }
 ```
 
-License: see [LICENSE](LICENSE).
+UFO is released under CC BY-NC 4.0 for non-commercial research use. See [LICENSE](LICENSE) for details.

--- a/README_zh-CN.md
+++ b/README_zh-CN.md
@@ -20,7 +20,7 @@
 
 ## UFO 是什么？
 
-UFO 是一个开源的无监督强化学习人形机器人控制框架。`main` 分支主要用于 MJLab 训练、RobotState 数据导入、tracking/goal/reward inference，以及 ONNX 导出。`deploy` 分支用于 Unitree G1 实机部署和遥操作运行时。
+UFO 是一个面向人形机器人控制、源代码可用的科研框架。`main` 分支主要用于 MJLab 训练、RobotState 数据导入、tracking/goal/reward inference，以及 ONNX 导出。`deploy` 分支用于 Unitree G1 实机部署和遥操作运行时。
 
 当前最完整、测试最充分的路线是 Unitree G1。新机器人适配已经有实验性接口，但需要用户准备目标机器人的 MuJoCo XML、可选 URDF，以及已经 retarget 到该机器人的 RobotState motion data。UFO 不会自动把人类动作或其他机器人的动作 retarget 到新机器人；不同机器人之间也不能直接复用同一个 checkpoint。
 
@@ -71,11 +71,14 @@ export PATH="$HOME/.local/bin:$PATH"
 uv sync
 ```
 
-如需使用 W&B：
+### 可选：W&B logging
+
+W&B logging 是可选功能。如需启用，请先登录，按需设置自己的 entity，然后在训练命令中加入 `--use-wandb --wandb-run-name ...`：
 
 ```bash
 uv run wandb login
-# 或者: export WANDB_API_KEY=your_wandb_api_key
+export WANDB_ENTITY=your_entity   # optional
+# 然后加入 --use-wandb --wandb-run-name ufo_fb_g1
 ```
 
 ### 2. 下载 G1 LaFAN 数据
@@ -110,9 +113,7 @@ CUDA_VISIBLE_DEVICES=0,1,2,3,4,5,6,7 \
   --work-dir runs/ufo_fb_g1 \
   --data-path humanoidverse/data/lafan_29dof_10s-clipped.pkl \
   --update-z-every-step 100 \
-  --buffer-size 5120000 \
-  --use-wandb \
-  --wandb-run-name ufo_fb_g1
+  --buffer-size 5120000
 ```
 
 ### 5. TeCH 训练
@@ -127,9 +128,7 @@ CUDA_VISIBLE_DEVICES=0,1,2,3,4,5,6,7 \
   --work-dir runs/ufo_tech_g1 \
   --data-path humanoidverse/data/lafan_29dof_10s-clipped.pkl \
   --update-z-every-step 10 \
-  --buffer-size 5120000 \
-  --use-wandb \
-  --wandb-run-name ufo_tech_g1
+  --buffer-size 5120000
 ```
 
 TeCH 在早期 UFO 版本中曾经叫 TLDR。`--agent tldr` 仍然保留为 `--agent tech` 的兼容 alias，但已经不推荐继续使用。
@@ -250,4 +249,4 @@ UFO 支持基于 manifest 的多数据源混合。每个数据源之间的采样
 
 在 LaTeX 中，将上述条目加入 `.bib` 文件后，使用 `\cite{ufo2026}` 即可。
 
-License: see [LICENSE](LICENSE).
+UFO 当前基于 CC BY-NC 4.0 发布，主要面向非商业科研使用，具体以 [LICENSE](LICENSE) 文件为准。

--- a/humanoidverse/train.py
+++ b/humanoidverse/train.py
@@ -228,7 +228,7 @@ def build_ufo_mjlab_config(
         use_trajectory_buffer=train_runtime["use_trajectory_buffer"],
         buffer_size=int(buffer_size),
         use_wandb=use_wandb,
-        wandb_ename=os.environ.get("WANDB_ENTITY", "xuewangusst-1"),
+        wandb_ename=os.environ.get("WANDB_ENTITY"),
         wandb_gname=wandb_group,
         wandb_pname=wandb_project,
         wandb_run_name=wandb_run_name or f"ufo_{agent}",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ dependencies = [
     "easydict>=1.13",
     "gymnasium>=0.29.0",
     "h5py>=3.14.0",
+    "huggingface-hub>=0.24.0",
     "hydra-core>=1.2.0",
     "joblib>=1.4.2",
     "loguru>=0.7.3",

--- a/scripts/download_data.sh
+++ b/scripts/download_data.sh
@@ -72,11 +72,29 @@ cleanup() {
 }
 trap cleanup EXIT
 
+if [[ -n "${HF_BIN:-}" ]]; then
+  :
+elif [[ -x ".venv/bin/hf" ]]; then
+  HF_BIN=".venv/bin/hf"
+elif command -v hf >/dev/null 2>&1; then
+  HF_BIN="$(command -v hf)"
+else
+  HF_BIN=""
+fi
+
+if [[ -n "${PYTHON:-}" ]]; then
+  PYTHON_BIN="${PYTHON}"
+elif [[ -x ".venv/bin/python" ]]; then
+  PYTHON_BIN=".venv/bin/python"
+else
+  PYTHON_BIN="python3"
+fi
+
 download_one() {
   local dataset_file="$1"
 
-  if command -v hf >/dev/null 2>&1; then
-    hf download "${DATASET_REPO}" \
+  if [[ -n "${HF_BIN}" ]]; then
+    "${HF_BIN}" download "${DATASET_REPO}" \
       "${dataset_file}" \
       --repo-type dataset \
       --revision "${DATASET_REVISION}" \
@@ -84,11 +102,11 @@ download_one() {
     return
   fi
 
-  if python3 - <<'PYTEST' >/dev/null 2>&1
+  if "${PYTHON_BIN}" - <<'PYTEST' >/dev/null 2>&1
 import huggingface_hub
 PYTEST
   then
-    python3 - "${DATASET_REPO}" "${dataset_file}" "${DATASET_REVISION}" "${tmpdir}" <<'PYDL'
+    "${PYTHON_BIN}" - "${DATASET_REPO}" "${dataset_file}" "${DATASET_REVISION}" "${tmpdir}" <<'PYDL'
 import sys
 from huggingface_hub import hf_hub_download
 

--- a/scripts/smoke_release.sh
+++ b/scripts/smoke_release.sh
@@ -8,8 +8,12 @@ export CUDA_VISIBLE_DEVICES
 
 echo "[smoke_release] CUDA_VISIBLE_DEVICES=${CUDA_VISIBLE_DEVICES}"
 
+uv run python tests/test_reference_observations.py
 uv run python tests/test_motion_data_adapter.py
 uv run python tests/test_import_tools.py
+uv run python tests/test_robot_config_training.py
+uv run python tests/test_robot_config_goal_reward_inference.py
+uv run python tests/test_robot_config_onnx_export.py
 uv run python -m compileall -q humanoidverse tests
 git diff --check
 

--- a/uv.lock
+++ b/uv.lock
@@ -47,6 +47,20 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/3e/38/7859ff46355f76f8d19459005ca000b6e7012f2f1ca597746cbcd1fbfe5e/antlr4-python3-runtime-4.9.3.tar.gz", hash = "sha256:f224469b4168294902bb1efa80a8bf7855f24c99aef99cbefc1bcd3cce77881b", size = 117034, upload-time = "2021-11-06T17:52:23.524Z" }
 
 [[package]]
+name = "anyio"
+version = "4.14.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "exceptiongroup" },
+    { name = "idna" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/61/cc/a381afa6efea9f496eff839d4a6a1aed3bfafc7b3ab4b0d1b243a12573dd/anyio-4.14.2.tar.gz", hash = "sha256:cfa139f3ed1a23ee8f88a145ddb5ac7605b8bbfd8592baacd7ce3d8bb4313c7f", size = 260176, upload-time = "2026-07-12T20:29:07.082Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/da/35/f2287558c17e29fafc8ef3daf819bb9834061cfa43bff8014f7df7f63bdc/anyio-4.14.2-py3-none-any.whl", hash = "sha256:9f505dda5ac9f0c8309b5e8bd445a8c2bf7246f3ce950121e45ea15bc41d1494", size = 125813, upload-time = "2026-07-12T20:29:05.763Z" },
+]
+
+[[package]]
 name = "asttokens"
 version = "3.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -167,14 +181,14 @@ wheels = [
 
 [[package]]
 name = "click"
-version = "8.2.1"
+version = "8.4.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/60/6c/8ca2efa64cf75a977a0d7fac081354553ebe483345c734fb6b6515d96bbc/click-8.2.1.tar.gz", hash = "sha256:27c491cc05d968d271d5a1db13e3b5a184636d9d930f148c50b038f0d0646202", size = 286342, upload-time = "2025-05-20T23:19:49.832Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/76/d4/81420972a676e8ffea40450d8c8c92943e7218a78fe9b64359836cc9876b/click-8.4.2.tar.gz", hash = "sha256:9a6cea6e60b17ebe0a44c5cc636d94f09bd66142c1cd7d8b4cd731c4917a15f6", size = 338000, upload-time = "2026-06-24T17:45:15.148Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/85/32/10bb5764d90a8eee674e9dc6f4db6a0ab47c8c4d0d83c27f7c39ac415a4d/click-8.2.1-py3-none-any.whl", hash = "sha256:61a3265b914e850b85317d0b3109c7f8cd35a670f963866005d6ef1d5175a12b", size = 102215, upload-time = "2025-05-20T23:19:47.796Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/e2/79c688af8b210d232694e31e59da9f6ec747bae31c3f5946e4e9b98860d5/click-8.4.2-py3-none-any.whl", hash = "sha256:e6f9f66136c816745b9d65817da91d61d957fb16e02e4dcd0552553c5a197b76", size = 119243, upload-time = "2026-06-24T17:45:13.73Z" },
 ]
 
 [[package]]
@@ -597,6 +611,15 @@ wheels = [
 ]
 
 [[package]]
+name = "h11"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250, upload-time = "2025-04-24T03:35:25.427Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515, upload-time = "2025-04-24T03:35:24.344Z" },
+]
+
+[[package]]
 name = "h5py"
 version = "3.16.0"
 source = { registry = "https://pypi.org/simple" }
@@ -612,6 +635,70 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/2b/ae/f2adc5d0ca9626db3277a3d87516e124cbc5d0eea0bd79bc085702d04f2c/h5py-3.16.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:1677ad48b703f44efc9ea0c3ab284527f81bc4f318386aaaebc5fede6bbae56f", size = 4839173, upload-time = "2026-03-06T13:47:43.586Z" },
     { url = "https://files.pythonhosted.org/packages/64/0b/e0c8c69da1d8838da023a50cd3080eae5d475691f7636b35eff20bb6ef20/h5py-3.16.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:7c4dd4cf5f0a4e36083f73172f6cfc25a5710789269547f132a20975bfe2434c", size = 5076216, upload-time = "2026-03-06T13:47:45.315Z" },
     { url = "https://files.pythonhosted.org/packages/66/35/d88fd6718832133c885004c61ceeeb24dbd6397ef877dbed6b3a64d6a286/h5py-3.16.0-cp310-cp310-win_amd64.whl", hash = "sha256:bdef06507725b455fccba9c16529121a5e1fbf56aa375f7d9713d9e8ff42454d", size = 3183639, upload-time = "2026-03-06T13:47:47.041Z" },
+]
+
+[[package]]
+name = "hf-xet"
+version = "1.5.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/63/39/67be8d71f900d9a55761b6022821d6679fb56c64f1b6063d5af2c2606727/hf_xet-1.5.2.tar.gz", hash = "sha256:73044bd31bae33c984af832d19c752a0dffb67518fee9ddbd91d616e1101cf47", size = 903674, upload-time = "2026-07-16T17:29:56.833Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/de/ba/2b70603c7552db82baeb2623e2336898304a17328845151be4fe1f48d420/hf_xet-1.5.2-cp38-abi3-macosx_10_12_x86_64.whl", hash = "sha256:f922b8f5fb84f1dd3d7ab7a1316354a1bca9b1c73ecfc19c76e51a2a49d29799", size = 4033760, upload-time = "2026-07-16T17:29:43.884Z" },
+    { url = "https://files.pythonhosted.org/packages/60/ac/b097a86a1e4a6098f3a79382643ab09d5733d87ccc864877ad1e12b49b70/hf_xet-1.5.2-cp38-abi3-macosx_11_0_arm64.whl", hash = "sha256:045f84440c55cdeb659cf1a1dd48c77bcd0d2e93632e2fea8f2c3bdee79f38ed", size = 3841438, upload-time = "2026-07-16T17:29:45.539Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/35/db860aa3a0780660324a506ad4b3d322ddc6ecbba4b9340aed0942cbf21c/hf_xet-1.5.2-cp38-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:db78c39c83d6279daddc98e2238f373ab8980685556d42472b4ec51abcf03e8c", size = 4428006, upload-time = "2026-07-16T17:29:46.996Z" },
+    { url = "https://files.pythonhosted.org/packages/af/6b/832dd980af4b0c3ae0660e309285f2ffcdff2faa38129390dbb47aa4a3f9/hf_xet-1.5.2-cp38-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:7db73c810500c54c6760be8c39d4b2e476974de85424c50063efc22fdda13025", size = 4221099, upload-time = "2026-07-16T17:29:48.525Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/05/ae50f0d34e3254e6c3e208beb2519f6b8673016fc4b3643badaf6450d186/hf_xet-1.5.2-cp38-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:6395cfe3c9cbead4f16b31808b0e67eac428b66c656f856e99636adaddea878f", size = 4420766, upload-time = "2026-07-16T17:29:50.092Z" },
+    { url = "https://files.pythonhosted.org/packages/07/a9/c050bc2743a2bcd68928bfee157b08681667a164a24ec95fbfcfcd717e08/hf_xet-1.5.2-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:cde8cd167126bb6109b2ceb19b844433a4988643e8f3e01dd9dd0e4a34535097", size = 4636716, upload-time = "2026-07-16T17:29:51.62Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/f8/68b01c5c2edb56ac9a67b3d076ffddcb90867abaee923923eb34e7a14e76/hf_xet-1.5.2-cp38-abi3-win_amd64.whl", hash = "sha256:ecf63d1cb69a9a7319910f8f83fcf9b46e7a32dfcf4b8f8eeddb55f647306e65", size = 3988373, upload-time = "2026-07-16T17:29:53.395Z" },
+    { url = "https://files.pythonhosted.org/packages/39/c6/988383e9dc17294d536fcbcd6fd16eed882e411ad16c954984a53e47b09c/hf_xet-1.5.2-cp38-abi3-win_arm64.whl", hash = "sha256:1da28519496eb7c8094c11e4d25509b4a468457a0302d58136099db2fd9a671d", size = 3816957, upload-time = "2026-07-16T17:29:54.991Z" },
+]
+
+[[package]]
+name = "httpcore"
+version = "1.0.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8", size = 85484, upload-time = "2025-04-24T22:06:22.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55", size = 78784, upload-time = "2025-04-24T22:06:20.566Z" },
+]
+
+[[package]]
+name = "httpx"
+version = "0.28.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "certifi" },
+    { name = "httpcore" },
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
+]
+
+[[package]]
+name = "huggingface-hub"
+version = "1.24.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "filelock" },
+    { name = "fsspec" },
+    { name = "hf-xet", marker = "platform_machine == 'AMD64' or platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'arm64' or platform_machine == 'x86_64'" },
+    { name = "httpx" },
+    { name = "packaging" },
+    { name = "pyyaml" },
+    { name = "tqdm" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/df/9b/d3bb4e7d792835daf34dd7091bbc7d7b4e0437d9388f1ea7239cce49f478/huggingface_hub-1.24.0.tar.gz", hash = "sha256:18431ff4daae0749aa9ba102fc952e314c98e1d30ebdec5319d85ca0a83e1ae5", size = 921848, upload-time = "2026-07-17T09:54:01.022Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5f/c3/aeaaf3911d2529614be18d1c8b5496afc185560e76568063d517283318af/huggingface_hub-1.24.0-py3-none-any.whl", hash = "sha256:6ed4120a84a6beec900640aa7e346bd766a6b7341e41526fef5dc8bd81fb7d59", size = 771904, upload-time = "2026-07-17T09:53:59.106Z" },
 ]
 
 [[package]]
@@ -2304,6 +2391,7 @@ dependencies = [
     { name = "easydict" },
     { name = "gymnasium" },
     { name = "h5py" },
+    { name = "huggingface-hub" },
     { name = "hydra-core" },
     { name = "joblib" },
     { name = "loguru" },
@@ -2336,6 +2424,7 @@ requires-dist = [
     { name = "easydict", specifier = ">=1.13" },
     { name = "gymnasium", specifier = ">=0.29.0" },
     { name = "h5py", specifier = ">=3.14.0" },
+    { name = "huggingface-hub", specifier = ">=0.24.0" },
     { name = "hydra-core", specifier = ">=1.2.0" },
     { name = "joblib", specifier = ">=1.4.2" },
     { name = "loguru", specifier = ">=0.7.3" },


### PR DESCRIPTION
## Summary

Post-release cleanup for UFO documentation, release usability, and smoke checks.

Changes:

- Clarify README wording for the current CC BY-NC 4.0 non-commercial research license.
- Update English and Chinese README from generic "open-source" wording to more accurate source-available / non-commercial research wording.
- Make W&B usage optional in the README examples.
- Remove the personal default W&B entity from `humanoidverse/train.py`.
- Add `huggingface-hub>=0.24.0` to dependencies and update `uv.lock`.
- Improve `scripts/download_data.sh` so it prefers `.venv/bin/hf` / `.venv/bin/python` after `uv sync`.
- Add recently introduced reference-observation and robot-config tests to `scripts/smoke_release.sh`.

## Checks

Passed on server:

```bash
uv run python tests/test_reference_observations.py
uv run python tests/test_motion_data_adapter.py
uv run python tests/test_import_tools.py
uv run python tests/test_robot_config_training.py
uv run python tests/test_robot_config_goal_reward_inference.py
uv run python tests/test_robot_config_onnx_export.py
uv run python -m compileall -q humanoidverse tests
git diff --check
bash -n scripts/smoke_release.sh
bash -n scripts/download_data.sh
bash scripts/download_data.sh g1_lafan
