### PR TITLE
Add and document soft-limit-aware action mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,6 +243,7 @@ UFO supports manifest-based, source-weighted multi-source data mixing. This is u
 
 - [Import Wizard](docs/import_wizard.md): RobotState schemas, inspection, and data building.
 - [Robot-Config Training](docs/robot_config_training.md): experimental robot-aware training initialization.
+- [Action Mappings](docs/action_mapping.md): effort/Kp and soft-joint-limit position-target mappings.
 - [Training and Inference](docs/TRAIN_INFERENCE.md): additional commands and runtime notes.
 - [Deploy branch](https://github.com/Roboparty/UFO/tree/deploy): G1 real-robot deployment and teleoperation runtime.
 

--- a/docs/action_mapping.md
+++ b/docs/action_mapping.md
@@ -1,0 +1,43 @@
+# Action-to-position-target mappings
+
+UFO policies emit normalized actions. The environment can convert them to
+joint-position targets with either of these mappings:
+
+- `effort_kp` (default) preserves the existing behavior. Its per-joint target
+  scale is derived from the configured action scale and, when action rescaling
+  is enabled, the effort-limit-to-stiffness ratio.
+- `soft_limit_bias` maps each clipped policy action in `[-1, 1]` affinely onto
+  that joint's configured soft position-limit interval.
+
+The second mapping is useful for robots with strongly asymmetric joint ranges.
+For a soft interval `[q_min, q_max]`, default position `q_default`, and MJLab
+target scale `s`, it computes
+
+```text
+lower = (q_min - q_default) / s
+upper = (q_max - q_default) / s
+bias = (lower + upper) / 2
+half_range = (upper - lower) / 2
+mapped_action = bias + half_range * clamp(policy_action, -1, 1)
+```
+
+Consequently, policy outputs `-1` and `1` correspond to `q_min` and `q_max`.
+The default remains `effort_kp`, so existing launch commands and checkpoints
+retain their current behavior.
+
+Select the alternative mapping when training:
+
+```bash
+./run_train.sh \
+  --agent fb \
+  --data-manifest configs/data/example_mix.yaml \
+  --rebuild-motion-cache \
+  --gpu-ids single \
+  --action-mapping soft_limit_bias \
+  --work-dir runs/ufo_fb_soft_limit_bias
+```
+
+Models trained with different mappings should be evaluated with the same
+mapping used during training. Tracking ONNX export records the mapping name and,
+for `soft_limit_bias`, the affine parameters and resolved soft limits in the
+companion `.meta.json` file.

--- a/docs/action_mapping.md
+++ b/docs/action_mapping.md
@@ -1,17 +1,35 @@
-# Action-to-position-target mappings
+# Action-to-position-target mappings / 动作到关节位置目标的映射
 
-UFO policies emit normalized actions. The environment can convert them to
-joint-position targets with either of these mappings:
+## Overview / 概述
+
+UFO interprets policy actions in a normalized action space. The environment can
+convert them to joint-position targets with either of the mappings below.
+
+UFO 在归一化动作空间中解释策略输出。环境可以使用下列两种映射之一，将策略动作转换为关节位置目标。
+
+## Mapping modes / 映射模式
 
 - `effort_kp` (default) preserves the existing behavior. Its per-joint target
   scale is derived from the configured action scale and, when action rescaling
   is enabled, the effort-limit-to-stiffness ratio.
-- `soft_limit_bias` maps each clipped policy action in `[-1, 1]` affinely onto
-  that joint's configured soft position-limit interval.
+- `soft_limit_bias` clips each policy action to `[-1, 1]` and maps it affinely
+  onto that joint's configured soft position-limit interval.
+
+- `effort_kp`（默认）保留原有行为。每个关节的位置目标缩放系数来自配置的 action scale；启用动作重缩放时，还会乘以该关节的力矩上限与刚度之比。
+- `soft_limit_bias` 先将每个策略动作裁剪到 `[-1, 1]`，再通过仿射变换将其映射到对应关节配置的软位置限位区间。
 
 The second mapping is useful for robots with strongly asymmetric joint ranges.
+Unlike a zero-centered scale, its bias lets the normalized action cover both
+ends of an asymmetric interval.
+
+第二种映射适用于关节范围明显不对称的机器人。与以零为中心的缩放不同，它通过偏置项使归一化动作能够覆盖不对称区间的两个端点。
+
+## Mapping formula / 映射公式
+
 For a soft interval `[q_min, q_max]`, default position `q_default`, and MJLab
-target scale `s`, it computes
+target scale `s`, the mapping computes:
+
+对于软限位区间 `[q_min, q_max]`、默认关节位置 `q_default` 和 MJLab 位置目标缩放系数 `s`，映射计算如下：
 
 ```text
 lower = (q_min - q_default) / s
@@ -21,11 +39,18 @@ half_range = (upper - lower) / 2
 mapped_action = bias + half_range * clamp(policy_action, -1, 1)
 ```
 
-Consequently, policy outputs `-1` and `1` correspond to `q_min` and `q_max`.
-The default remains `effort_kp`, so existing launch commands and checkpoints
-retain their current behavior.
+Consequently, policy outputs `-1` and `1` reconstruct `q_min` and `q_max`
+after MJLab applies its default-position offset and target scale. The default
+remains `effort_kp`, so existing launch commands and checkpoints retain their
+current behavior.
 
-Select the alternative mapping when training:
+因此，在 MJLab 应用默认关节位置偏置和位置目标缩放后，策略输出 `-1` 和 `1` 会分别还原为 `q_min` 和 `q_max`。默认模式仍为 `effort_kp`，所以已有启动命令和检查点的行为不会改变。
+
+## Training usage / 训练用法
+
+Select the alternative mapping explicitly when training:
+
+训练时需要显式选择新的映射模式：
 
 ```bash
 ./run_train.sh \
@@ -38,6 +63,15 @@ Select the alternative mapping when training:
 ```
 
 Models trained with different mappings should be evaluated with the same
-mapping used during training. Tracking ONNX export records the mapping name and,
-for `soft_limit_bias`, the affine parameters and resolved soft limits in the
-companion `.meta.json` file.
+mapping used during training.
+
+使用不同映射训练的模型，在评估时必须继续使用各自训练时的映射。
+
+## ONNX metadata / ONNX 元数据
+
+Tracking ONNX export records the mapping name in the companion `.meta.json`
+file. For `soft_limit_bias`, it also records the affine bias and range, action
+input endpoints, MJLab target scales, default joint positions, and resolved
+soft position limits.
+
+Tracking ONNX 导出会在配套的 `.meta.json` 文件中记录映射名称。对于 `soft_limit_bias`，还会记录仿射偏置与范围、动作输入端点、MJLab 位置目标缩放系数、默认关节位置以及最终解析出的软位置限位。

--- a/docs/action_mapping.md
+++ b/docs/action_mapping.md
@@ -24,6 +24,66 @@ ends of an asymmetric interval.
 
 第二种映射适用于关节范围明显不对称的机器人。与以零为中心的缩放不同，它通过偏置项使归一化动作能够覆盖不对称区间的两个端点。
 
+## Concrete G1 example / G1 具体例子
+
+The repository's G1 configuration provides a concrete asymmetric case. For
+`left_hip_roll_joint`, it specifies:
+
+仓库中的 G1 配置提供了一个具体的不对称关节案例。对于 `left_hip_roll_joint`，配置为：
+
+```text
+hard limits        = [-0.52360, 2.96710] rad = [-30.00°, 170.00°]
+soft-limit factor  = 0.95
+soft limits        = [-0.43633, 2.87983] rad = [-25.00°, 165.00°]
+default position   = 0 rad
+effort limit       = 139 N·m
+Kp                 = 99.09843 N·m/rad
+base action scale  = 0.25
+action normalize   = 5.0
+```
+
+With the existing mapping, the MJLab target scale is
+`s = 0.25 * 139 / 99.09843 = 0.35066`. A normalized policy action
+`a in [-1, 1]` is first multiplied by `5`, producing this target interval:
+
+使用现有映射时，MJLab 的位置目标缩放系数为
+`s = 0.25 * 139 / 99.09843 = 0.35066`。归一化策略动作
+`a in [-1, 1]` 会先乘以 `5`，因此得到的位置目标区间为：
+
+```text
+q_target = q_default + s * (5 * a)
+         = [-1.75331, 1.75331] rad
+         = [-100.46°, 100.46°]
+```
+
+The negative side requests positions far beyond the joint's `-25°` soft
+limit, while the positive side cannot reach the `165°` soft upper limit; it is
+short by `1.12653 rad` (`64.55°`). The mirrored right-hip-roll joint has the
+same problem in the opposite direction.
+
+负方向的位置目标远远超过关节 `-25°` 的软下限，而正方向最多只能到 `100.46°`，距离 `165°` 的软上限还差 `1.12653 rad`（`64.55°`）。镜像的右髋 roll 关节则在相反方向存在同样的问题。
+
+For the same joint, `soft_limit_bias` computes the action-space endpoints and
+affine parameters as follows:
+
+对于同一个关节，`soft_limit_bias` 计算出的动作空间端点和仿射参数为：
+
+```text
+lower      = -1.24431
+upper      =  8.21257
+bias       =  3.48413
+half_range =  4.72844
+```
+
+Therefore policy outputs `-1`, `0`, and `1` produce position targets `-25°`,
+`70°`, and `165°`, respectively. This proves the coverage property of the
+mapping: both soft-limit endpoints are reachable and no normalized-action
+range is allocated to targets outside that interval. It is a geometric
+correctness argument, not by itself a claim that every training task must
+improve.
+
+因此，策略输出 `-1`、`0` 和 `1` 时，位置目标分别为 `-25°`、`70°` 和 `165°`。这证明了该映射的空间覆盖性质：两个软限位端点均可达，且不会把归一化动作范围浪费在软限位区间之外。这是对映射几何正确性的证明，但它本身不等价于“所有训练任务都必然获得提升”。
+
 ## Mapping formula / 映射公式
 
 For a soft interval `[q_min, q_max]`, default position `q_default`, and MJLab

--- a/humanoidverse/agents/envs/humanoidverse_mjlab.py
+++ b/humanoidverse/agents/envs/humanoidverse_mjlab.py
@@ -281,6 +281,31 @@ def _action_target_scale(config) -> torch.Tensor:
     return torch.tensor(scales, dtype=torch.float32)
 
 
+def _soft_limit_action_affine(
+    soft_limits: torch.Tensor,
+    default_pos: torch.Tensor,
+    target_scale: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Build an affine map from normalized actions to soft joint limits.
+
+    ``JointPositionAction`` applies ``default_pos + target_scale * action``.
+    This helper expresses the desired soft-limit interval in that action input
+    space, so ``bias + half_range * normalized_action`` reaches both limits
+    when the normalized policy output spans ``[-1, 1]``.
+    """
+    scale = target_scale.squeeze(0)
+    if torch.any(scale <= 0.0):
+        raise ValueError("soft_limit_bias action mapping requires positive target scales")
+    default = default_pos[0]
+    lower = (soft_limits[:, 0] - default) / scale
+    upper = (soft_limits[:, 1] - default) / scale
+    if torch.any(lower >= upper):
+        raise ValueError("soft_limit_bias action mapping received invalid soft joint limits")
+    bias = 0.5 * (upper + lower)
+    half_range = 0.5 * (upper - lower)
+    return bias, half_range, lower, upper
+
+
 def _small_random_quaternions(n: int, max_angle: float, device: str) -> torch.Tensor:
     axis = torch.randn((n, 3), device=device)
     axis = axis / torch.clamp(torch.norm(axis, dim=1, keepdim=True), min=1.0e-6)
@@ -676,6 +701,31 @@ class HumanoidVerseMjlabCore:
         center = (lower + upper) * 0.5
         radius = (upper - lower) * 0.5 * limit_scale
         self.dof_pos_limits = torch.stack((center - radius, center + radius), dim=-1)
+        self.action_mapping = creation_config.action_mapping
+        self.action_mapping_bias = torch.zeros(self.num_dof, device=self.device)
+        self.action_mapping_range = torch.ones(self.num_dof, device=self.device)
+        self.action_mapping_lower = -torch.ones(self.num_dof, device=self.device)
+        self.action_mapping_upper = torch.ones(self.num_dof, device=self.device)
+        if self.action_mapping == "soft_limit_bias":
+            (
+                self.action_mapping_bias,
+                self.action_mapping_range,
+                self.action_mapping_lower,
+                self.action_mapping_upper,
+            ) = _soft_limit_action_affine(
+                self.dof_pos_limits,
+                self.default_dof_pos,
+                self.action_target_scale,
+            )
+            print(
+                "[INFO] action_mapping=soft_limit_bias "
+                f"soft_limit_factor={limit_scale:g} "
+                f"lower={self.action_mapping_lower.tolist()} "
+                f"upper={self.action_mapping_upper.tolist()} "
+                f"bias={self.action_mapping_bias.tolist()} "
+                f"range={self.action_mapping_range.tolist()}",
+                flush=True,
+            )
         self.torque_limits = torch.tensor(_to_list(hv_config.robot.dof_effort_limit_list), device=self.device, dtype=torch.float32)
         self.dof_vel_limits = torch.tensor(_to_list(hv_config.robot.dof_vel_limit_list), device=self.device, dtype=torch.float32)
 
@@ -1016,6 +1066,9 @@ class HumanoidVerseMjlabCore:
         return reward, aux
 
     def _normalized_action(self, actions: torch.Tensor) -> torch.Tensor:
+        if self.action_mapping == "soft_limit_bias":
+            normalized = torch.clamp(actions, -1.0, 1.0)
+            return self.action_mapping_bias + self.action_mapping_range * normalized
         if bool(self.config.robot.control.normalize_action):
             actions = actions * float(self.config.robot.control.normalize_action_to) / float(self.config.robot.control.normalize_action_from)
         return torch.clamp(actions, -float(self.config.robot.control.action_clip_value), float(self.config.robot.control.action_clip_value))
@@ -1275,6 +1328,7 @@ class HumanoidVerseMjlabConfig(BaseConfig):
     max_episode_length_s: float | None = None
     disable_obs_noise: bool = False
     disable_domain_randomization: bool = False
+    action_mapping: tp.Literal["effort_kp", "soft_limit_bias"] = "effort_kp"
     relative_config_path: str = HYDRA_CONFIG_REL_PATH
     include_last_action: bool = True
     hydra_overrides: tp.List[str] = pydantic.Field(default_factory=list)

--- a/humanoidverse/tracking_inference.py
+++ b/humanoidverse/tracking_inference.py
@@ -98,7 +98,32 @@ def _tracking_z(model: torch.nn.Module, obs: Any) -> torch.Tensor:
     return model.project_z(z)
 
 
-def _export_policy_model(model: torch.nn.Module, output_dir: Path, robot_training: Any) -> dict[str, Any]:
+def _action_mapping_export_metadata(env: Any | None) -> dict[str, Any]:
+    if env is None:
+        return {}
+    mapping = str(env.action_mapping)
+    metadata: dict[str, Any] = {"action_mapping": mapping}
+    if mapping == "soft_limit_bias":
+        metadata.update(
+            {
+                "action_mapping_bias": env.action_mapping_bias.detach().cpu().tolist(),
+                "action_mapping_range": env.action_mapping_range.detach().cpu().tolist(),
+                "action_mapping_lower": env.action_mapping_lower.detach().cpu().tolist(),
+                "action_mapping_upper": env.action_mapping_upper.detach().cpu().tolist(),
+                "action_target_scale": env.action_target_scale[0].detach().cpu().tolist(),
+                "default_dof_pos": env.default_dof_pos[0].detach().cpu().tolist(),
+                "soft_dof_pos_limits": env.dof_pos_limits.detach().cpu().tolist(),
+            }
+        )
+    return metadata
+
+
+def _export_policy_model(
+    model: torch.nn.Module,
+    output_dir: Path,
+    robot_training: Any,
+    env: Any | None = None,
+) -> dict[str, Any]:
     output_dir.mkdir(parents=True, exist_ok=True)
     model_name = model.__class__.__name__
     output_name = f"{model_name}.onnx"
@@ -122,6 +147,7 @@ def _export_policy_model(model: torch.nn.Module, output_dir: Path, robot_trainin
             "xml_path": str(Path(robot_training.robot.xml_path).expanduser().resolve()),
             "num_dof": num_dof,
             "control_joint_names": control_joint_names,
+            **_action_mapping_export_metadata(env),
         }
     )
     metadata_path = output_dir / f"{model_name}.meta.json"
@@ -131,8 +157,8 @@ def _export_policy_model(model: torch.nn.Module, output_dir: Path, robot_trainin
     return export_metadata
 
 
-def _export_tracking_onnx(model: torch.nn.Module, output_dir: Path, robot_training: Any) -> None:
-    _export_policy_model(model, output_dir, robot_training)
+def _export_tracking_onnx(model: torch.nn.Module, output_dir: Path, robot_training: Any, env: Any | None = None) -> None:
+    _export_policy_model(model, output_dir, robot_training, env)
     try:
         export_backward_encoder_from_model(model, output_dir / "backward_encoder.onnx")
     except UnsupportedBackwardEncoderExport as exc:
@@ -192,9 +218,6 @@ def run_tracking_inference(
     model.to(device)
     model.eval()
 
-    if export_onnx:
-        _export_tracking_onnx(model, model_folder / "exported", robot_training)
-
     env_cfg, use_root_height_obs = load_mjlab_env_cfg(
         model_folder,
         data_path=data_path,
@@ -207,6 +230,9 @@ def run_tracking_inference(
     )
     wrapped_env, _ = env_cfg.build(num_envs=1)
     env = wrapped_env._env
+
+    if export_onnx:
+        _export_tracking_onnx(model, model_folder / "exported", robot_training, env)
 
     output_dir = model_folder / "tracking_inference"
     output_dir.mkdir(parents=True, exist_ok=True)

--- a/humanoidverse/train.py
+++ b/humanoidverse/train.py
@@ -113,6 +113,7 @@ def build_ufo_mjlab_config(
     cartwheel_aux_safe: bool = False,
     num_agent_updates: int | None = None,
     robot_config: str | Path | None = None,
+    action_mapping: str = "effort_kp",
 ) -> TrainConfig:
     agent = canonical_agent_name(agent)
     robot_training = load_robot_training_spec(robot_config or DEFAULT_ROBOT_CONFIG)
@@ -200,6 +201,7 @@ def build_ufo_mjlab_config(
             max_episode_length_s=None,
             disable_obs_noise=disable_obs_noise,
             disable_domain_randomization=disable_dr,
+            action_mapping=action_mapping,
             relative_config_path="exp/bfm_zero/bfm_zero",
             include_last_action=True,
             hydra_overrides=hydra_overrides,
@@ -319,6 +321,7 @@ def run_train(args: argparse.Namespace, log_dir: Path) -> None:
         cartwheel_aux_safe=bool(args.cartwheel_aux_safe),
         num_agent_updates=args.num_agent_updates,
         robot_config=args.robot_config,
+        action_mapping=args.action_mapping,
     )
     print(
         "[INFO] UFO train: "
@@ -328,7 +331,8 @@ def run_train(args: argparse.Namespace, log_dir: Path) -> None:
         f"num_envs_per_rank={args.num_envs}, global_parallel_envs={args.num_envs * world_size}, "
         f"num_env_steps_global={args.num_env_steps}, buffer_size_per_rank={cfg.buffer_size}, "
         f"num_agent_updates={cfg.num_agent_updates}, update_agent_every_local={cfg.update_agent_every}, "
-        f"cartwheel_aux_safe={args.cartwheel_aux_safe}, lr_scale={args.lr_scale}, clip_grad_norm={args.clip_grad_norm}, "
+        f"cartwheel_aux_safe={args.cartwheel_aux_safe}, action_mapping={args.action_mapping}, "
+        f"lr_scale={args.lr_scale}, clip_grad_norm={args.clip_grad_norm}, "
         f"disable_dr={cfg.env.disable_domain_randomization}, disable_obs_noise={cfg.env.disable_obs_noise}, "
         f"compile={cfg.agent.compile}",
         flush=True,
@@ -453,6 +457,15 @@ def parse_args() -> argparse.Namespace:
         help="Override latent update interval. Defaults to 100 for FB and 10 for TeCH.",
     )
     parser.add_argument("--buffer-size", type=int, default=DEFAULT_BUFFER_SIZE, help="Replay capacity per rank/GPU.")
+    parser.add_argument(
+        "--action-mapping",
+        choices=("effort_kp", "soft_limit_bias"),
+        default="effort_kp",
+        help=(
+            "Action-to-position-target mapping. effort_kp preserves the existing effort/Kp scaling; "
+            "soft_limit_bias maps [-1, 1] affinely onto each joint's configured soft limits."
+        ),
+    )
     parser.add_argument(
         "--num-agent-updates",
         type=int,

--- a/tests/test_action_mapping.py
+++ b/tests/test_action_mapping.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+import unittest
+from unittest.mock import patch
+
+import torch
+
+from humanoidverse.agents.envs.humanoidverse_mjlab import _soft_limit_action_affine
+from humanoidverse.train import build_ufo_mjlab_config, parse_args
+
+
+class SoftLimitActionMappingTest(unittest.TestCase):
+    def test_cli_default_preserves_existing_mapping(self) -> None:
+        with patch("sys.argv", ["train.py", "--smoke"]):
+            args = parse_args()
+        self.assertEqual(args.action_mapping, "effort_kp")
+
+    def test_cli_mapping_reaches_environment_config(self) -> None:
+        cfg = build_ufo_mjlab_config(
+            device="cpu",
+            work_dir="/tmp/ufo_action_mapping_test",
+            num_envs=1,
+            num_env_steps=1,
+            seed=1,
+            use_wandb=False,
+            wandb_run_name=None,
+            smoke=True,
+            action_mapping="soft_limit_bias",
+        )
+        self.assertEqual(cfg.env.action_mapping, "soft_limit_bias")
+
+    def test_endpoints_reconstruct_soft_limits(self) -> None:
+        soft_limits = torch.tensor([[-1.2, 2.4], [-0.5, 0.7]], dtype=torch.float32)
+        default_pos = torch.tensor([[0.3, -0.1]], dtype=torch.float32)
+        target_scale = torch.tensor([[0.6, 0.2]], dtype=torch.float32)
+
+        bias, half_range, lower, upper = _soft_limit_action_affine(
+            soft_limits,
+            default_pos,
+            target_scale,
+        )
+
+        torch.testing.assert_close(bias - half_range, lower)
+        torch.testing.assert_close(bias + half_range, upper)
+        torch.testing.assert_close(default_pos[0] + target_scale[0] * lower, soft_limits[:, 0])
+        torch.testing.assert_close(default_pos[0] + target_scale[0] * upper, soft_limits[:, 1])
+
+    def test_asymmetric_limits_produce_nonzero_bias(self) -> None:
+        soft_limits = torch.tensor([[-0.2, 1.0]], dtype=torch.float32)
+        default_pos = torch.tensor([[0.0]], dtype=torch.float32)
+        target_scale = torch.tensor([[0.5]], dtype=torch.float32)
+
+        bias, half_range, _, _ = _soft_limit_action_affine(soft_limits, default_pos, target_scale)
+
+        torch.testing.assert_close(bias, torch.tensor([0.8]))
+        torch.testing.assert_close(half_range, torch.tensor([1.2]))
+
+    def test_nonpositive_target_scale_is_rejected(self) -> None:
+        soft_limits = torch.tensor([[-1.0, 1.0]], dtype=torch.float32)
+        default_pos = torch.tensor([[0.0]], dtype=torch.float32)
+
+        with self.assertRaisesRegex(ValueError, "positive target scales"):
+            _soft_limit_action_affine(soft_limits, default_pos, torch.tensor([[0.0]]))
+
+    def test_invalid_limits_are_rejected(self) -> None:
+        soft_limits = torch.tensor([[1.0, -1.0]], dtype=torch.float32)
+        default_pos = torch.tensor([[0.0]], dtype=torch.float32)
+
+        with self.assertRaisesRegex(ValueError, "invalid soft joint limits"):
+            _soft_limit_action_affine(soft_limits, default_pos, torch.tensor([[1.0]]))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_robot_config_onnx_export.py
+++ b/tests/test_robot_config_onnx_export.py
@@ -203,6 +203,34 @@ class RobotConfigOnnxExportTest(unittest.TestCase):
         self.assertEqual(saved["actor_obs_dim"], 52 + 27 + 100 + 12)
         self.assertEqual(saved["output_action_dim"], 27)
 
+    def test_tracking_policy_export_writes_soft_limit_mapping_metadata(self) -> None:
+        model = _FakePolicyModel(state_dim=52, last_action_dim=2, action_dim=2)
+        env = SimpleNamespace(
+            action_mapping="soft_limit_bias",
+            action_mapping_bias=torch.tensor([0.25, -0.5]),
+            action_mapping_range=torch.tensor([1.5, 2.0]),
+            action_mapping_lower=torch.tensor([-1.25, -2.5]),
+            action_mapping_upper=torch.tensor([1.75, 1.5]),
+            action_target_scale=torch.tensor([[0.4, 0.2]]),
+            default_dof_pos=torch.tensor([[0.1, -0.2]]),
+            dof_pos_limits=torch.tensor([[-0.4, 0.8], [-0.7, 0.1]]),
+        )
+
+        with tempfile.TemporaryDirectory() as tmpdir, patch("humanoidverse.utils.helpers.torch.onnx.export"):
+            metadata = _export_policy_model(model, Path(tmpdir), _fake_robot_training(2), env)
+            saved = json.loads((Path(tmpdir) / "_FakePolicyModel.meta.json").read_text())
+
+        self.assertEqual(metadata["action_mapping"], "soft_limit_bias")
+        self.assertEqual(saved["action_mapping_bias"], [0.25, -0.5])
+        self.assertEqual(saved["action_mapping_range"], [1.5, 2.0])
+        self.assertTrue(torch.allclose(torch.tensor(saved["action_target_scale"]), torch.tensor([0.4, 0.2])))
+        self.assertTrue(
+            torch.allclose(
+                torch.tensor(saved["soft_dof_pos_limits"]),
+                torch.tensor([[-0.4, 0.8], [-0.7, 0.1]]),
+            )
+        )
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary / 概述

This PR adds an optional `soft_limit_bias` action-to-position-target mapping.
It maps a clipped policy output in `[-1, 1]` affinely onto each joint's
configured soft position limits, including the offset required by asymmetric
joint ranges.

本 PR 新增了可选的 `soft_limit_bias` 动作到关节位置目标映射。它将裁剪到 `[-1, 1]` 的策略输出仿射映射到各关节配置的软位置限位，并包含覆盖不对称关节范围所需的偏置。

The existing `effort_kp` mapping remains the default, so existing commands and
checkpoints keep their current behavior.

现有的 `effort_kp` 映射仍然是默认选项，因此已有命令和检查点的行为保持不变。

## Motivation / 动机

The existing effort/Kp-derived scale is centered on the configured default
joint position. For joints with asymmetric ranges, the reachable target range
can be asymmetric or may not cover the full useful joint interval. The new
mapping computes the bias and half-range after accounting for MJLab's default
offset and per-joint target scale, so normalized endpoints reconstruct the
configured soft limits exactly.

现有的 effort/Kp 缩放以配置的默认关节位置为中心。对于限位不对称的关节，可达目标范围可能不对称，或无法覆盖完整的有效关节区间。新映射在考虑 MJLab 的默认位置偏置和逐关节目标缩放后计算 bias 与 half-range，使归一化动作的两个端点能够精确还原配置的软限位。

### Concrete G1 example / G1 具体例子

The G1 `left_hip_roll_joint` is a concrete asymmetric example from the
repository's existing configuration:

G1 的 `left_hip_roll_joint` 是仓库现有配置中的一个具体不对称案例：

| Quantity / 配置项 | Value / 数值 |
|---|---:|
| Hard limits / 硬限位 | `[-0.52360, 2.96710] rad` = `[-30.00°, 170.00°]` |
| Soft limits (`0.95`) / 软限位 | `[-0.43633, 2.87983] rad` = `[-25.00°, 165.00°]` |
| Default position / 默认位置 | `0 rad` |
| Effort limit / 力矩上限 | `139 N·m` |
| Kp / 位置刚度 | `99.09843 N·m/rad` |
| Base action scale / 基础动作缩放 | `0.25` |

The existing mapping gives
`s = 0.25 * 139 / 99.09843 = 0.35066`. After the configured `5x` action
normalization, `a in [-1, 1]` produces:

现有映射得到 `s = 0.25 * 139 / 99.09843 = 0.35066`。经过配置中的 `5x` 动作归一化后，`a in [-1, 1]` 产生：

```text
q_target = 0 + 0.35066 * (5 * a)
         = [-1.75331, 1.75331] rad
         = [-100.46°, 100.46°]
```

Thus much of the negative action range requests targets below the `-25°` soft
limit, while the positive target is still `64.55°` short of the `165°` soft
upper limit. The mirrored right-hip-roll joint has the same issue in the
opposite direction.

因此，大量负方向动作对应的目标落在 `-25°` 软下限之外，而正方向最大目标距离 `165°` 软上限仍差 `64.55°`。镜像的右髋 roll 关节在相反方向存在同样的问题。

`soft_limit_bias` instead yields `bias = 3.48413` and
`half_range = 4.72844`, so policy outputs `-1`, `0`, and `1` map exactly to
`-25°`, `70°`, and `165°`. Both soft-limit endpoints are reachable without
allocating normalized-action range to out-of-limit targets.

`soft_limit_bias` 则得到 `bias = 3.48413`、`half_range = 4.72844`，使策略输出 `-1`、`0` 和 `1` 精确对应 `-25°`、`70°` 和 `165°`。这样既能覆盖两个软限位端点，也不会把归一化动作范围分配给限位之外的位置目标。

This establishes the mapping's geometric coverage property. It does not, by
itself, claim that every downstream task must improve; the controlled A/B
result below provides the empirical evidence.

这证明了映射在关节空间覆盖上的几何正确性，但不单独宣称所有下游任务都必然提升；下方的受控 A/B 实验提供经验结果。

## Changes / 改动内容

- Add `--action-mapping {effort_kp,soft_limit_bias}` to the training CLI.
- Apply the affine mapping before passing actions to MJLab.
- Preserve `effort_kp` as the backward-compatible default.
- Record the mapping and resolved affine parameters in tracking ONNX metadata.
- Add endpoint, asymmetric-limit, invalid-input, CLI-default, and config
  propagation tests.
- Document the mapping and its formula in English and Chinese.

- 在训练 CLI 中新增 `--action-mapping {effort_kp,soft_limit_bias}`。
- 将动作传给 MJLab 前应用仿射映射。
- 保留 `effort_kp` 作为向后兼容的默认选项。
- 在 tracking ONNX 元数据中记录映射模式和解析后的仿射参数。
- 增加端点、不对称限位、非法输入、CLI 默认值和配置传递测试。
- 使用中英双语说明映射方法及其公式。

## Controlled A/B result / 受控 A/B 实验结果

The two Roban FB runs used the same motion data, seed, optimizer settings, and
2-GPU setup. Both reached approximately 106 million global environment steps.
The table reports the mean of the final 100 logged samples.

两组 Roban FB 实验使用相同的动作数据、随机种子、优化器配置和双 GPU 设置，均训练到约 1.06 亿 global environment steps。下表统计最后 100 条训练日志的平均值。

| Metric / 指标 | `effort_kp` | `soft_limit_bias` | Change / 变化 |
|---|---:|---:|---:|
| Joint-limit penalty / 关节限位惩罚（越低越好） | 0.01081 | 0.00613 | -43.27% |
| Torque-limit penalty / 力矩限位惩罚（越低越好） | 0.13127 | 0.03621 | -72.42% |
| Squared-torque metric / 力矩平方指标（越低越好） | 5834.43 | 4727.19 | -18.98% |
| F1 representation metric / F1 表征指标（越高越好） | 0.26356 | 0.33274 | +26.25% |

W&B runs / W&B 实验链接：

- Baseline / 基线：https://wandb.ai/xiechunyang1-hajimi/hajimi/runs/63m9byv1
- Soft-limit affine / 软限位仿射映射：https://wandb.ai/xiechunyang1-hajimi/hajimi/runs/ccdkmded

<!-- Drag action_mapping_training_ab.png below this line. / 请将 action_mapping_training_ab.png 拖到此行下方。 -->

This is a one-seed result on one robot. Downstream tracking improvements vary
by motion, so the new behavior is intentionally opt-in rather than replacing
the default.

该结果来自单一机器人和单一随机种子。下游跟踪效果会随动作变化，因此新映射被设计为显式启用的可选功能，而不是直接替换默认行为。

## Test plan / 测试方案

```text
/home/thl/wt_wbc/UFO/.venv/bin/python -m unittest \
  tests.test_action_mapping \
  tests.test_update_z_cli \
  tests.test_robot_config_onnx_export

Ran 20 tests: OK
```
<img width="1962" height="1260" alt="action_mapping_training_ab" src="https://github.com/user-attachments/assets/f7ba53d4-6686-498b-9fc3-2ac9f6c683ce" />

The tests cover the affine endpoint reconstruction, asymmetric bias,
invalid inputs, backward-compatible CLI defaults, environment-config
propagation, and ONNX mapping metadata.

测试覆盖仿射映射端点还原、不对称偏置、非法输入、向后兼容的 CLI 默认值、环境配置传递和 ONNX 映射元数据。

這個在實物和sim2sim上會有更好的效果,更好的達到工作空間.
